### PR TITLE
Fixed glfwGetCurrentContext() to return null when there is no context.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,3 +1,4 @@
 "Harry Stern" <hstern@google.com>
 "Jason Daly" <dalyj@google.com>
 "Todd Larsen" <tlarsen@google.com>
+"Michael McLennan" <nefario@google.com>

--- a/example/example_es2_window.dart
+++ b/example/example_es2_window.dart
@@ -49,8 +49,6 @@ void main() {
   GLFWwindow window = glfwCreateWindow(640, 480, "Hello Dart GLFW", null, null);
   print("window: $window");
 
-  glfwMakeContextCurrent(window);
-
   glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_HIDDEN);
 
   glfwSetWindowPosCallback(window, winMoveCallback);
@@ -60,8 +58,14 @@ void main() {
   glfwSetKeyCallback(window, keypressCallback);
 
   while (!glfwWindowShouldCloseAsBool(window)) {
+    // Context can be activated for drawing...
+    glfwMakeContextCurrent(window);
+
     glfwPollEvents();
     glfwSwapBuffers(window);
+
+    // ...and context can be deactivated until later.
+    glfwMakeContextCurrent(null);
   }
   glfwTerminate();
 }

--- a/lib/src/instantiate_glfw_classes.cc
+++ b/lib/src/instantiate_glfw_classes.cc
@@ -48,6 +48,8 @@ Dart_Handle NewRectangle(int left, int top, int width, int height) {
 }
 
 Dart_Handle NewGLFWwindow(GLFWwindow *window) {
+  if (window == NULL) return Dart_Null();
+
   Dart_Handle GLFWwindow_type = HandleError(Dart_GetType(
       GLFWLibrary, Dart_NewStringFromCString("GLFWwindow"), 0, NULL));
 


### PR DESCRIPTION
As it was, it was taking the NULL pointer and wrapping it up in a "window" object, so it looked like there was always some context in place.  We need to activate a context, draw, and deactivate the context (as shown in the example) to keep everything thread safe in the Dart vm.  It helps to know when the context is active and when it's not.
