### PR TITLE
Change dart:convert "UTF8" -> "utf8".

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: glfw
-version: "1.0.1"
+version: 1.0.2-dev
 description: Dart GLFW bindings
 authors:
   - John McDole <codefu@google.com>
@@ -8,7 +8,7 @@ authors:
   - Harry Stern <hstern@google.com>
 homepage:
 environment:
-  sdk: ">=1.10.0"
+  sdk: ">=2.0.0-dev.36.0 <3.0.0"
 dev_dependencies:
   ccompile: "^0.2.10"
   path: "^1.3.9"

--- a/tools/glfw_generator.dart
+++ b/tools/glfw_generator.dart
@@ -49,7 +49,7 @@ main(List<String> args) async {
   var readStream = new File(path.join(glfwPath, 'glfw3.h')).openRead();
   var defineRegex = new RegExp(r'#define GLFW_[^ ]+\s+\d+');
   await for (var line
-      in readStream.transform(UTF8.decoder).transform(new LineSplitter())) {
+      in readStream.transform(utf8.decoder).transform(new LineSplitter())) {
     if (line.contains(defineRegex)) {
       defines.add(line.substring('#define '.length).trim());
     } else if (line.startsWith('GLFWAPI ')) {


### PR DESCRIPTION
The former will be removed in Dart 2, so this gets it ready for that.
The new names were already introduced in a previous dev version.