### PR TITLE
Prepare for upcoming change to File.openRead()

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: glfw
-version: 1.0.2
+version: 1.0.2+1
 description: Dart GLFW bindings
 authors:
   - John McDole <codefu@google.com>

--- a/tools/glfw_generator.dart
+++ b/tools/glfw_generator.dart
@@ -48,8 +48,10 @@ main(List<String> args) async {
 
   var readStream = new File(path.join(glfwPath, 'glfw3.h')).openRead();
   var defineRegex = new RegExp(r'#define GLFW_[^ ]+\s+\d+');
-  await for (var line
-      in readStream.transform(utf8.decoder).transform(new LineSplitter())) {
+  await for (var line in readStream
+      .cast<List<int>>()
+      .transform(utf8.decoder)
+      .transform(new LineSplitter())) {
     if (line.contains(defineRegex)) {
       defines.add(line.substring('#define '.length).trim());
     } else if (line.startsWith('GLFWAPI ')) {


### PR DESCRIPTION
An upcoming change to the Dart SDK will change the signature
of `File.openRead()` from returning `Stream<List<int>>` to
returning `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

dart-lang/sdk#36900