### PR TITLE
Remove unused dart:async import

### DIFF
--- a/lib/glfw.dart
+++ b/lib/glfw.dart
@@ -13,7 +13,6 @@
 /// for more detail.
 library glfw;
 
-import 'dart:async';
 import 'dart:isolate';
 
 import 'dart-ext:glfw_extension';


### PR DESCRIPTION
Since Dart 2.1, Future/Stream have been exported by dart:core